### PR TITLE
Add minimal 'Rakefile'

### DIFF
--- a/runger_rails_model_explorer/Rakefile
+++ b/runger_rails_model_explorer/Rakefile
@@ -1,0 +1,1 @@
+require 'rake'

--- a/runger_rails_model_explorer/Rakefile
+++ b/runger_rails_model_explorer/Rakefile
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require 'rake'


### PR DESCRIPTION
It seems to be required for `rake` to work. I'm getting this error when trying to release:

```
[runger_release_assistant] Running system command `bundle exec rake release`
rake aborted!
No Rakefile found (looking for: rakefile, Rakefile, rakefile.rb, Rakefile.rb)
/home/david/.rbenv/versions/3.4.2/bin/bundle:25:in 'Kernel#load'
/home/david/.rbenv/versions/3.4.2/bin/bundle:25:in '<main>'
(See full trace by running task with --trace)
```

Hopefully this will be enough for `rake` to work.