### PR TITLE
Add repository, homepage, author, and license fields to package.json

### DIFF
--- a/vue-model-explorer/CHANGELOG.md
+++ b/vue-model-explorer/CHANGELOG.md
@@ -1,0 +1,2 @@
+## v0.0.2 (2025-03-19)
+- Add `repository`, `homepage`, `author`, and `license` fields to `package.json`.

--- a/vue-model-explorer/CHANGELOG.md
+++ b/vue-model-explorer/CHANGELOG.md
@@ -1,2 +1,3 @@
 ## v0.0.2 (2025-03-19)
+
 - Add `repository`, `homepage`, `author`, and `license` fields to `package.json`.

--- a/vue-model-explorer/package.json
+++ b/vue-model-explorer/package.json
@@ -38,5 +38,12 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/davidrunger/vue_rails_model_explorer.git"
+  },
+  "homepage": "https://github.com/davidrunger/vue_rails_model_explorer/tree/main/vue-model-explorer#readme",
+  "author": "David Runger",
+  "license": "MIT"
 }

--- a/vue-model-explorer/package.json
+++ b/vue-model-explorer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@davidrunger/vue-model-explorer",
   "private": false,
-  "version": "0.0.1",
+  "version": "0.0.2",
   "type": "module",
   "module": "./index.js",
   "exports": {


### PR DESCRIPTION
This should make some useful links appear at https://www.npmjs.com/package/@davidrunger/vue-model-explorer that aren't there now.