### PR TITLE
[package.json] Remove "module" field

### DIFF
--- a/vue-model-explorer/CHANGELOG.md
+++ b/vue-model-explorer/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.0.3 (2025-03-19)
+
+- Remove `"module"` field from `package.json`.
+
 ## v0.0.2 (2025-03-19)
 
 - Add `repository`, `homepage`, `author`, and `license` fields to `package.json`.

--- a/vue-model-explorer/package.json
+++ b/vue-model-explorer/package.json
@@ -1,9 +1,8 @@
 {
   "name": "@davidrunger/vue-model-explorer",
   "private": false,
-  "version": "0.0.2",
+  "version": "0.0.3",
   "type": "module",
-  "module": "./index.js",
   "exports": {
     ".": {
       "import": "./index.js"


### PR DESCRIPTION
Per [this answer][1], it's not officially supported, and I don't think we get any benefit from it, so let's not have it.

[1]: https://stackoverflow.com/a/42817320/4009384