### PR TITLE
Specify Ruby version in Gemfile via '.ruby-version' file

### DIFF
--- a/runger_rails_model_explorer/Gemfile
+++ b/runger_rails_model_explorer/Gemfile
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+ruby file: '.ruby-version'
+
 source 'https://rubygems.org'
 
 gemspec


### PR DESCRIPTION
_Maybe_ (just a random hope) this will fix our Dependabot issue? `tool_version_not_supported {:"tool-name"=>"ruby", :"detected-version"=>">= 3.4.2", :"supported-versions"=>"1.8.7, 1.9.3, 2.0.0, 2.1.10, 2.2.10, 2.3.8, 2.4.10, 2.5.9, 2.6.9, 2.7.6, 3.0.6, 3.1.6, 3.2.4, 3.3.6"}`

https://github.com/davidrunger/vue_rails_model_explorer/actions/runs/13975523726/job/39128212568
https://github.com/dependabot/dependabot-core/issues/ 11427