### PR TITLE
Support pinning the column lists of multiple models [ME-3]

### DIFF
--- a/vue-model-explorer/CHANGELOG.md
+++ b/vue-model-explorer/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.2.0 (2025-03-21)
+
+- Support pinning the column lists of multiple models simultaneously.
+
 ## v0.1.0 (2025-03-21)
 
 - Add quick-selector typeahead.

--- a/vue-model-explorer/package.json
+++ b/vue-model-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@davidrunger/vue-model-explorer",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Render info about your Rails models in a keyboard-navigable linked graph.",
   "author": "David Runger",
   "type": "module",


### PR DESCRIPTION
https://claude.ai/chat/643511ac-4edd-4976-8b4e-a05b488fb9c1

Currently, we can only view the columns of any one model at a time. I think that, sometimes, it will be useful to be able to view the columns of multiple models at once.

This change adds a button for the currently focused model that can toggle whether the model is "pinned". Hitting the "p" key also toggles the model's pinned status. When pinned, the model's name and its columns will be added to a new left-hand sidebar, where they will remain until unpinned (via button click or the "p" key). This will allow pinning multiple models at once, to be viewed together.

For the sake of not showing an overwhelming amount of information, we'll only show the columns for the pinned models, not their associations.