### PR TITLE
Add spacing between column name and type [ME-8]

### DIFF
--- a/vue-model-explorer/CHANGELOG.md
+++ b/vue-model-explorer/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.2.1 (2025-03-21)
+
+- Add space between column name and type.
+- Remove parentheses around column type.
+- Render model name in bold rather than italics.
+- Remove "Associations" heading.
+
 ## v0.2.0 (2025-03-21)
 
 - Support pinning the column lists of multiple models simultaneously.

--- a/vue-model-explorer/package.json
+++ b/vue-model-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@davidrunger/vue-model-explorer",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Render info about your Rails models in a keyboard-navigable linked graph.",
   "author": "David Runger",
   "type": "module",

--- a/vue-model-explorer/src/ModelGraph.vue
+++ b/vue-model-explorer/src/ModelGraph.vue
@@ -20,9 +20,7 @@
             :title="`Null: ${column.null}\nDefault: ${column.default}`"
           )
             b.font-mono {{ column.name }}
-            |
-            |
-            span.text-neutral-400 ({{ column.type }})
+            i.ml-2.text-neutral-400 {{ column.type }}
 
   // Center: the graph visualization and footer container.
   .flex.flex-col.h-dvh.flex-1
@@ -35,7 +33,7 @@
   aside.flex.flex-col.w-100.border-l.p-2.text-lg
     // Model name with pin toggle.
     .flex.items-center.mb-2.pl-6
-      h2.text-3xl.font-mono.italic.mb-0 {{ focusedNodeData.modelName }}
+      h2.text-3xl.font-mono.font-bold.mb-0 {{ focusedNodeData.modelName }}
       button.ml-2(
         @click="toggleFocusedModelPinnedState"
         :title="isPinned(focusedNodeData.id) ? 'Unpin model' : 'Pin model'"
@@ -50,14 +48,11 @@
         :title="`Null: ${column.null}\nDefault: ${column.default}`"
       )
         b.font-mono {{ column.name }}
-        |
-        |
-        span.text-neutral-400 ({{ column.type }})
+        i.ml-2.text-neutral-400 {{ column.type }}
 
     // Associations section.
-    h3.text-center.mt-4 Associations
     template(v-if="focusedNodeData.associations.length")
-      ul.associations.list-none.pl-0.overflow-y-scroll
+      ul.associations.list-none.mt-8.pl-0.overflow-y-scroll
         li.text-sm.mb-2(
           v-for="(association, index) in focusedNodeData.associations"
           :key="association.name"


### PR DESCRIPTION
Also, italicize the type and remove the wrapping parentheses. The lighter gray color and italics are enough to set it apart visually; the parens are just clutter.

Also, render model name with bold font, rather than italics.

Also, remove "Associations" heading. I think it's relatively obvious what is in that section, and I think it looks a bit cleaner without the label. Also, this is consistent with our not having a "Columns" label for that section.

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/f0907114-d858-4bd2-869f-37e775c7e4dc) | ![image](https://github.com/user-attachments/assets/65bd3fc8-3f86-4f73-b5a2-611fe5837fbf) |
