### PR TITLE
Update README screenshots to one that has latest visual improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Vue Rails Model Explorer](https://github.com/user-attachments/assets/ef0d2303-a70a-4e1c-8a96-5c40a7a1a484)
+![Vue Rails Model Explorer](https://david-runger-public-uploads.s3.us-east-1.amazonaws.com/vue-rails-model-explorer.png)
 
 # Vue Rails Model Explorer
 

--- a/runger_rails_model_explorer/README.md
+++ b/runger_rails_model_explorer/README.md
@@ -1,4 +1,4 @@
-![Vue Rails Model Explorer](https://github.com/user-attachments/assets/ef0d2303-a70a-4e1c-8a96-5c40a7a1a484)
+![Vue Rails Model Explorer](https://david-runger-public-uploads.s3.us-east-1.amazonaws.com/vue-rails-model-explorer.png)
 
 # RungerRailsModelExplorer
 

--- a/vue-model-explorer/README.md
+++ b/vue-model-explorer/README.md
@@ -1,4 +1,4 @@
-![Vue Rails Model Explorer](https://github.com/user-attachments/assets/ef0d2303-a70a-4e1c-8a96-5c40a7a1a484)
+![Vue Rails Model Explorer](https://david-runger-public-uploads.s3.us-east-1.amazonaws.com/vue-rails-model-explorer.png)
 
 # Vue Model Explorer
 


### PR DESCRIPTION
Also, use the image hosted in my david-runger-public-uploads S3 bucket, rather than hosted by GitHub. One good thing about this is that, if I change the image in the future, then I won't need to update these image URLs.

I used these commands to give it a 60-second cache TTL, to make it render in the browser (rather than downloading), and to set the appropriate content-type header:

```sh
aws s3 cp s3://david-runger-public-uploads/vue-rails-model-explorer.png s3://david-runger-public-uploads/vue-rails-model-explorer.png --metadata-directive REPLACE \
--cache-control max-age=60,public

aws s3 cp s3://david-runger-public-uploads/vue-rails-model-explorer.png s3://david-runger-public-uploads/vue-rails-model-explorer.png \
--content-disposition "inline"

aws s3 cp s3://david-runger-public-uploads/vue-rails-model-explorer.png s3://david-runger-public-uploads/vue-rails-model-explorer.png \
--content-type "image/png"
```